### PR TITLE
Make convenient = false work.

### DIFF
--- a/server.js
+++ b/server.js
@@ -217,7 +217,7 @@ Response.prototype.end = function(value) {
   var self = this
 
   var msg = convenient.final_response(self, value)
-    , data = msg.toBinary()
+    , data = msg ? msg.toBinary() : self.toBinary()
 
   if(self.connection.type == 'udp4' && data.length > 512)
     return self.emit('error', 'UDP responses greater than 512 bytes not yet implemented')


### PR DESCRIPTION
Without convenient = true, the convenient.final_response does nothing (returns undefined), so next msg.toBinary() call throws exception.
As there is no another place in the code to encode and send response, this fix looks reasonable.
