### PR TITLE
Increased max_iterations

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -211,7 +211,7 @@ State.prototype.encode = function(full_domain, position_offset, option) {
     , bytes
 
   var i = 0
-  var max_iterations = 40 // Enough for 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa
+  var max_iterations = 127 // Theoretical upper limit for number of labels in a DNS name; see https://en.wikipedia.org/wiki/Subdomain#Overview
 
   while(++i < max_iterations) {
     if(domain == '') {


### PR DESCRIPTION
Although 40 labels seems high enough for most use cases (e.g. reverse resolution of a IPv6 address) our project ran into issues with a domain name with 45 labels. To avoid problems in the future, I suggest to allow for the maximum number of labels allowed for a domain name. Since the function stops immediately when a shorter DNS name is processed, this should not have any impact for other users of this library.
