### PR TITLE
NXDOMAIN response flag for empty answer

### DIFF
--- a/convenient.js
+++ b/convenient.js
@@ -57,8 +57,13 @@ function final_response(res, value) {
 
   res.authoritative = !! soa_record
 
+  // Empty replies need to get the NXDOMAIN flag set
+  if(typeof value == 'undefined') {
+	  res.not_found = true
+  }
+  
   // Add convenience for typical name resolution.
-  if(questions.length == 1 && question.kind() == 'IN A') {
+  else if(questions.length == 1 && question.kind() == 'IN A') {
     // If the value given is an IP address, make that the answer.
     if(typeof value == 'string' && answers.length == 0)
       res.answer.push({'class':'IN', 'type':'A', 'name':question.name, 'data':value})

--- a/encode.js
+++ b/encode.js
@@ -65,6 +65,7 @@ State.prototype.message = function(msg) {
   byte |= msg.recursion_available ? 0x80 : 0x00
   byte |= msg.authenticated       ? 0x20 : 0x00
   byte |= msg.checking_disabled   ? 0x10 : 0x00
+  byte |= msg.not_found           ? 0x03 : 0x00
   byte |= (msg.responseCode & 0x0f)
 
   self.header.writeUInt8(byte, 3)
@@ -211,7 +212,7 @@ State.prototype.encode = function(full_domain, position_offset, option) {
     , bytes
 
   var i = 0
-  var max_iterations = 40 // Enough for 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa
+  var max_iterations = 80 // Enough for 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa
 
   while(++i < max_iterations) {
     if(domain == '') {

--- a/message.js
+++ b/message.js
@@ -50,6 +50,7 @@ function DNSMessage (body) {
   this.recursion_available = null
   this.authenticated       = null
   this.checking_disabled   = null
+  this.not_found           = null
 
   if(Buffer.isBuffer(body))
     this.parse(body)


### PR DESCRIPTION
When you deliberately send an empty result using `res.end();` the default convenience behavior would set the DNS return code 0 ("NOERROR"). Instead, the return code 3 ("NXDOMAIN") would be more appropriate. While technically, NOERROR is fine even if the response contains no answer, this patch will avoid the "Zero answer bug" which is already mentioned in RFC 1536. 
