### PR TITLE
Tests failure: Invalid requests test broken

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -270,6 +270,8 @@ function domain_parts(msg, offset) {
   while(true) {
     if(++i >= 100)
       throw new Error('Too many iterations uncompressing name')
+    else if(msg.length <= offset)
+      throw new Error('Received invalid request')
 
     var byte = msg.readUInt8(offset)
       , flags = byte >> 6

--- a/test/server.js
+++ b/test/server.js
@@ -124,8 +124,8 @@ test('Network queries', function(t) {
 })
 
 test('Invalid queries', function(t) {
-  var reqs = { 'short-query'                  : { message:'Error processing request', error: 'RangeError: Trying to access beyond buffer length' }
-             , 'garbage'                      : { message:'Error processing request', error: 'RangeError: Trying to access beyond buffer length' }
+  var reqs = { 'short-query'                  : { message:'Error processing request', error: 'Error: Received invalid request' }
+             , 'garbage'                      : { message:'Error processing request', error: 'Error: Received invalid request' }
              }
 
   var i = 0


### PR DESCRIPTION
* tests for invalid requests was broken due the error message being different
* fixed by adding new error message if the message is too short