### PR TITLE
added IPv6 validation adjustment

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -1,7 +1,7 @@
 // Copyright 2012 Iris Couch, all rights reserved.
 //
 // Encode DNS messages
-
+const ip6 = require('ip6');
 var util = require('util')
 
 var constants = require('./constants')
@@ -128,7 +128,7 @@ State.prototype.record = function(section_name, record) {
         rdata = [ +match[1], +match[2], +match[3], +match[4] ]
         break
       case 'IN AAAA':
-        rdata = (record.data || '').split(/:/)
+        rdata = (ip6.normalize(record.data) || '').split(/:/)
         if(rdata.length != 8)
           throw new Error('Bad '+record.type+' record data: ' + JSON.stringify(record))
         rdata = rdata.map(pair_to_buf)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dnsd",
     "iris"
   ],
-  "version": "0.9.6",
+  "version": "0.9.7",
   "author": "Jason Smith <jason.h.smith@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,37 @@
-{ "name": "dnsd"
-, "description": "Dynamic authoritative name server for Iris services"
-
-, "keywords": [ "dns", "bind", "dnsd", "iris" ]
-, "version": "0.9.6"
-, "author": "Jason Smith <jason.h.smith@gmail.com>"
-, "repository": { "type":"git", "url":"https://github.com/jhs/dnsd" }
-, "licenses": [{ "type": "Apache 2.0", "url": "https://github.com/jhs/dnsd/blob/master/LICENSE" }]
-
-, "engines": { "node": ">= 0.8" }
-, "main": "./named.js"
-
-, "dependencies": { "optimist": "~0.3.4"
-                  , "defaultable": "~0.7.2"
-                  }
-, "devDependencies": { "tap": "~0.2.5"
-                     }
-, "scripts": { "test": "tap test/*.js" }
+{
+  "name": "dnsd",
+  "description": "Dynamic authoritative name server for Iris services",
+  "keywords": [
+    "dns",
+    "bind",
+    "dnsd",
+    "iris"
+  ],
+  "version": "0.9.6",
+  "author": "Jason Smith <jason.h.smith@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jhs/dnsd"
+  },
+  "licenses": [
+    {
+      "type": "Apache 2.0",
+      "url": "https://github.com/jhs/dnsd/blob/master/LICENSE"
+    }
+  ],
+  "engines": {
+    "node": ">= 0.8"
+  },
+  "main": "./named.js",
+  "dependencies": {
+    "defaultable": "~0.7.2",
+    "ip6": "^0.1.5",
+    "optimist": "~0.3.4"
+  },
+  "devDependencies": {
+    "tap": "~0.2.5"
+  },
+  "scripts": {
+    "test": "tap test/*.js"
+  }
 }


### PR DESCRIPTION
Original code can not process shorten IPv6 addresses: 
`Error: Bad AAAA record data: {"name":"bitbucket.org","type":"AAAA","data":"2401:1d80:1010::150","ttl":3600,"class":"IN"}`